### PR TITLE
Avoid regression for span<bool> from C++23 to C++26

### DIFF
--- a/src/remote_fmt/remote_fmt.hpp
+++ b/src/remote_fmt/remote_fmt.hpp
@@ -683,8 +683,9 @@ static constexpr auto format_to(Printer&                     printer,
 
 template<typename ComBackend>
 struct Printer {
-private:
-    void constexpr lowprint(std::span<std::byte const> span) {
+private:    
+    template<std::size_t Extent = std::dynamic_extent>
+    void constexpr lowprint(std::span<std::byte const, Extent> span) {
         if constexpr(requires { ComBackend::write(span); }) {
             ComBackend::write(span);
         } else {
@@ -698,10 +699,21 @@ private:
         lowprint(std::as_bytes(std::span{range}));
     }
 
-    template<typename... Ts>
-        requires(std::is_trivially_copyable_v<Ts> && ...)
-    constexpr void printHelper(Ts const&... values) {
-        (lowprint(std::span{std::addressof(values), 1}), ...);
+    constexpr void printHelper(auto&&... values)
+        requires (sizeof...(values) > 1 && (... && std::is_trivially_copyable_v<std::remove_cvref_t<decltype(values)>>))
+    {
+        (printHelper(std::forward<decltype(values)>(values)), ...);
+    }
+
+    constexpr void printHelper(bool value) {
+        std::byte const data{value};
+        lowprint(std::span<std::byte const, 1>{&data, std::size_t{1}});
+    }
+
+    template <typename Type>
+        requires(std::is_trivially_copyable_v<Type> && !std::is_same_v<Type, bool>)
+    constexpr void printHelper(Type const& value) {
+        lowprint(std::span<Type const, 1>{std::addressof(value), 1});
     }
 
     template<typename T>


### PR DESCRIPTION
std::span gains an initializer list constructor in C++26.

Some compilers end up preferring that constructor over the prior choice in C++23 under certain circumstances, resulting in a span of different size/type than previously. This is especially risky for a span of `bool` because both pointer addresses and size types can be implicitly converted to `bool`.

Previously, for all types `T`, a `span<T>` is created and then converted to a `span<byte>`.

This merge request overloads the remote_fmt implementation for the type `bool` so that instead of 
> T -> std::span\<T\> -> std::span\<std::byte\>

a `bool` is converted differently:
> bool -> std::byte -> std::span

This avoids the ambiguity of span construction differences with different C++ standard versions.

